### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -170,7 +170,7 @@ class HydratorTest extends TestCase
             'value' => 'yes',
         ]);
 
-        $this->assertSame(true, $object->value);
+        $this->assertTrue($object->value);
     }
 
     public function testHydratePropertyWithStringIntegerNumber() : void


### PR DESCRIPTION
# Changed log

- Using the `assertTrue` to assert expected `true`.