### PR TITLE
v3.9.0

### DIFF
--- a/src/Exception/InvalidDataException.php
+++ b/src/Exception/InvalidDataException.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sunrise\Hydrator\Exception;
 
-use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use RuntimeException;
@@ -58,20 +57,8 @@ class InvalidDataException extends RuntimeException implements ExceptionInterfac
     final public function getViolations(): ConstraintViolationListInterface
     {
         $violations = new ConstraintViolationList();
-
         foreach ($this->exceptions as $exception) {
-            $violations->add(
-                new ConstraintViolation(
-                    $exception->getMessage(),
-                    $exception->getMessageTemplate(),
-                    $exception->getMessagePlaceholders(),
-                    null,
-                    $exception->getPropertyPath(),
-                    null,
-                    null,
-                    $exception->getErrorCode()
-                )
-            );
+            $violations->add($exception->getViolation());
         }
 
         return $violations;

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -111,7 +111,7 @@ class InvalidValueException extends RuntimeException implements ExceptionInterfa
     }
 
     /**
-     * @since 3.8.0
+     * @since 3.9.0
      */
     final public function getViolation(): ConstraintViolationInterface
     {

--- a/src/Exception/InvalidValueException.php
+++ b/src/Exception/InvalidValueException.php
@@ -16,6 +16,8 @@ namespace Sunrise\Hydrator\Exception;
 use Sunrise\Hydrator\Dictionary\ErrorCode;
 use Sunrise\Hydrator\Dictionary\ErrorMessage;
 use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 
 use function join;
 use function strtr;
@@ -93,7 +95,7 @@ class InvalidValueException extends RuntimeException implements ExceptionInterfa
      *
      * @since 3.7.0
      */
-    public function getMessageTemplate(): string
+    final public function getMessageTemplate(): string
     {
         return $this->messageTemplate;
     }
@@ -103,9 +105,26 @@ class InvalidValueException extends RuntimeException implements ExceptionInterfa
      *
      * @since 3.7.0
      */
-    public function getMessagePlaceholders(): array
+    final public function getMessagePlaceholders(): array
     {
         return $this->messagePlaceholders;
+    }
+
+    /**
+     * @since 3.8.0
+     */
+    final public function getViolation(): ConstraintViolationInterface
+    {
+        return new ConstraintViolation(
+            $this->getMessage(),
+            $this->getMessageTemplate(),
+            $this->getMessagePlaceholders(),
+            null,
+            $this->getPropertyPath(),
+            null,
+            null,
+            $this->getErrorCode(),
+        );
     }
 
     /**


### PR DESCRIPTION
The method [InvalidValueException::getViolation()](https://github.com/sunrise-php/hydrator/blob/2235784eeae7e4ff5d5d3e7c11fb91fc724d1917/src/Exception/InvalidValueException.php#L116-L128) was added.