### PR TITLE
v3.12.0

### DIFF
--- a/src/Annotation/DefaultValue.php
+++ b/src/Annotation/DefaultValue.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2021, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/hydrator/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/hydrator
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Hydrator\Annotation;
+
+use Attribute;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ * @NamedArgumentConstructor
+ *
+ * @Attributes({
+ *     @Attribute("value", type="mixed", required=true),
+ * })
+ *
+ * @since 3.12.0
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class DefaultValue
+{
+
+    /**
+     * The attribute value
+     *
+     * @var mixed
+     *
+     * @readonly
+     */
+    public $value;
+
+    /**
+     * Constructor of the class
+     *
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Annotation/Subtype.php
+++ b/src/Annotation/Subtype.php
@@ -35,6 +35,13 @@ class Subtype
 {
 
     /**
+     * @var mixed
+     *
+     * @internal
+     */
+    public $holder = null;
+
+    /**
      * @var non-empty-string
      *
      * @readonly

--- a/src/Exception/InvalidObjectException.php
+++ b/src/Exception/InvalidObjectException.php
@@ -112,9 +112,11 @@ class InvalidObjectException extends LogicException implements ExceptionInterfac
      *
      * @since 3.2.0
      */
-    // phpcs:ignore Generic.Files.LineLength
-    final public static function unsupportedMethodParameterType(Type $type, ReflectionParameter $parameter, ReflectionMethod $method): self
-    {
+    final public static function unsupportedMethodParameterType(
+        Type $type,
+        ReflectionParameter $parameter,
+        ReflectionMethod $method
+    ): self {
         return new self(sprintf(
             'The parameter {%s::%s($%s[%d])} is associated with an unsupported type {%s}.',
             $method->getDeclaringClass()->getName(),
@@ -134,9 +136,11 @@ class InvalidObjectException extends LogicException implements ExceptionInterfac
      *
      * @since 3.2.0
      */
-    // phpcs:ignore Generic.Files.LineLength
-    final public static function unsupportedFunctionParameterType(Type $type, ReflectionParameter $parameter, ReflectionFunctionAbstract $function): self
-    {
+    final public static function unsupportedFunctionParameterType(
+        Type $type,
+        ReflectionParameter $parameter,
+        ReflectionFunctionAbstract $function
+    ): self {
         return new self(sprintf(
             'The parameter {%s($%s[%d])} is associated with an unsupported type {%s}.',
             $function->getName(),

--- a/src/TypeConverter/ArrayTypeConverter.php
+++ b/src/TypeConverter/ArrayTypeConverter.php
@@ -96,7 +96,7 @@ final class ArrayTypeConverter implements
             return yield $value;
         }
 
-        if (isset($subtype->limit) && count($value) > $subtype->limit) {
+        if ($subtype->limit !== null && count($value) > $subtype->limit) {
             throw InvalidValueException::arrayOverflow($path, $subtype->limit);
         }
 
@@ -116,11 +116,11 @@ final class ArrayTypeConverter implements
             }
         }
 
-        if ($violations === []) {
-            return yield $value;
+        if ($violations !== []) {
+            throw new InvalidDataException('Invalid data', $violations);
         }
 
-        throw new InvalidDataException('Invalid data', $violations);
+        yield $value;
     }
 
     /**

--- a/src/TypeConverter/BackedEnumTypeConverter.php
+++ b/src/TypeConverter/BackedEnumTypeConverter.php
@@ -16,7 +16,6 @@ namespace Sunrise\Hydrator\TypeConverter;
 use BackedEnum;
 use Generator;
 use ReflectionEnum;
-use ReflectionNamedType;
 use Sunrise\Hydrator\Dictionary\BuiltinType;
 use Sunrise\Hydrator\Exception\InvalidValueException;
 use Sunrise\Hydrator\Type;
@@ -54,11 +53,7 @@ final class BackedEnumTypeConverter implements TypeConverterInterface
             return;
         }
 
-        /** @var ReflectionNamedType $enumType */
-        $enumType = (new ReflectionEnum($enumName))->getBackingType();
-
-        /** @var BuiltinType::INT|BuiltinType::STRING $enumTypeName */
-        $enumTypeName = $enumType->getName();
+        $enumTypeName = (string) (new ReflectionEnum($enumName))->getBackingType();
 
         if (is_string($value)) {
             $value = trim($value);

--- a/src/TypeConverter/TimestampTypeConverter.php
+++ b/src/TypeConverter/TimestampTypeConverter.php
@@ -83,8 +83,9 @@ final class TimestampTypeConverter implements TypeConverterInterface, Annotation
             throw InvalidObjectException::unsupportedType($type);
         }
 
-        // phpcs:ignore Generic.Files.LineLength
-        $format = $this->annotationReader->getAnnotations(Format::class, $type->getHolder())->current()->value ?? $context[ContextKey::TIMESTAMP_FORMAT] ?? self::DEFAULT_FORMAT;
+        $format = $this->annotationReader->getAnnotations(Format::class, $type->getHolder())->current()->value
+            ?? $context[ContextKey::TIMESTAMP_FORMAT]
+            ?? self::DEFAULT_FORMAT;
 
         if (is_string($value)) {
             $value = trim($value);

--- a/tests/Fixture/BooleanArrayCollection.php
+++ b/tests/Fixture/BooleanArrayCollection.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sunrise\Hydrator\Tests\Fixture;
+
+use ArrayObject;
+use Sunrise\Hydrator\Annotation\Subtype;
+use Sunrise\Hydrator\Dictionary\BuiltinType;
+
+final class BooleanArrayCollection extends ArrayObject
+{
+    public function __construct(#[Subtype(BuiltinType::BOOL)] array ...$elements)
+    {
+        parent::__construct($elements);
+    }
+}


### PR DESCRIPTION
* The [DefaultValue](https://github.com/sunrise-php/hydrator/blob/8d5445843dc8cc179b34b82a9c9599779e8bb051/src/Annotation/DefaultValue.php) annotation was added; use it in `abstract readonly` classes to assign default values to their properties;
* The typed parameter of a collection is now a type holder, rather than a property referring to such a collection.